### PR TITLE
contract fixes

### DIFF
--- a/contracts/testing/StakingToken.sol
+++ b/contracts/testing/StakingToken.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.3;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract StakingToken is ERC20 {
+  constructor() ERC20("StakingToken", "STKN") {}
+
+  function mint(address _to, uint256 _amount) public {
+    _mint(_to, _amount);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -25,5 +25,9 @@
     "hardhat": "^2.7.1",
     "prettier": "^2.5.1",
     "prettier-plugin-solidity": "^1.0.0-beta.19"
+  },
+  "dependencies": {
+    "@openzeppelin/contracts": "^4.4.0",
+    "web3": "^1.6.1"
   }
 }


### PR DESCRIPTION
- move appropriate mappings to StakeInfo and Report structs
- add `_amount` arg to `depositStake` function
- fix rounding error in `submitValue`. Multiply by 1000
- make `submitValue` `_nonce` arg optional