### PR TITLE
allow depositStake from partial lockedBalance

### DIFF
--- a/contracts/TellorFlex.sol
+++ b/contracts/TellorFlex.sol
@@ -88,7 +88,10 @@ contract TellorFlex {
      */
     function changeGovernanceAddress(address _newGovernanceAddress) external {
         require(msg.sender == governance, "caller must be governance address");
-        require(_newGovernanceAddress != address(0), "must set governance address");
+        require(
+            _newGovernanceAddress != address(0),
+            "must set governance address"
+        );
         governance = _newGovernanceAddress;
         emit NewGovernanceAddress(_newGovernanceAddress);
     }
@@ -99,7 +102,10 @@ contract TellorFlex {
      */
     function changeReportingLock(uint256 _newReportingLock) external {
         require(msg.sender == governance, "caller must be governance address");
-        require(_newReportingLock > 0, "reporting lock must be greater than zero");
+        require(
+            _newReportingLock > 0,
+            "reporting lock must be greater than zero"
+        );
         reportingLock = _newReportingLock;
         emit NewReportingLock(_newReportingLock);
     }
@@ -121,8 +127,19 @@ contract TellorFlex {
      */
     function depositStake(uint256 _amount) external {
         StakeInfo storage _staker = stakerDetails[msg.sender];
-        if (_staker.lockedBalance >= _amount) {
-            _staker.lockedBalance -= _amount;
+        if (_staker.lockedBalance > 0) {
+            if (_staker.lockedBalance >= _amount) {
+                _staker.lockedBalance -= _amount;
+            } else {
+                require(
+                    token.transferFrom(
+                        msg.sender,
+                        address(this),
+                        _amount - _staker.lockedBalance
+                    )
+                );
+                _staker.lockedBalance = 0;
+            }
         } else {
             require(token.transferFrom(msg.sender, address(this), _amount));
         }

--- a/test/functionTests-TellorFlex.js
+++ b/test/functionTests-TellorFlex.js
@@ -80,6 +80,13 @@ describe("TellorFlex", function() {
 		expect(stakerDetails[3]).to.equal(0)
 		expect(stakerDetails[4]).to.equal(0)
 		expect(await tellor.totalStakeAmount()).to.equal(web3.utils.toWei("10"))
+		await tellor.connect(accounts[1]).requestStakingWithdraw(h.toWei("5"))
+		await tellor.connect(accounts[1]).depositStake(h.toWei("10"))
+		expect(await token.balanceOf(accounts[1].address)).to.equal(web3.utils.toWei("985"))
+		stakerDetails = await tellor.getStakerInfo(accounts[1].address)
+		expect(stakerDetails[1]).to.equal(web3.utils.toWei("15"))
+		expect(stakerDetails[2]).to.equal(0)
+		expect(await tellor.totalStakeAmount()).to.equal(web3.utils.toWei("15"))
 	})
 
 	it("removeValue", async function() {


### PR DESCRIPTION
- depositStake fix from [Steffengy audit](https://github.com/tellor-io/tellorFlex/issues/17). Allows using partial stake from locked balance. 