### PR TITLE
Tracking staked trb

### DIFF
--- a/contracts/TellorFlex.sol
+++ b/contracts/TellorFlex.sol
@@ -274,6 +274,12 @@ contract TellorFlex {
         rep.timestampToBlockNum[block.timestamp] = block.number;
         rep.valueByTimestamp[block.timestamp] = _value;
         rep.reporterByTimestamp[block.timestamp] = msg.sender;
+        // Disperse Time Based Reward
+        uint256 _timeDiff = block.timestamp - timeOfLastNewValue;
+        uint256 _reward = (_timeDiff * timeBasedReward) / 300; //.5 TRB per 5 minutes
+        if (_reward > 0) {
+            token.transfer(msg.sender, _reward);
+        }
         // Update last oracle value and number of values submitted by a reporter
         timeOfLastNewValue = block.timestamp;
         _staker.reportsSubmitted++;

--- a/contracts/TellorFlex.sol
+++ b/contracts/TellorFlex.sol
@@ -14,7 +14,7 @@ import "./interfaces/IERC20.sol";
 contract TellorFlex {
     IERC20 public token;
     address public governance;
-    uint256 public timeBasedReward;
+    uint256 public timeBasedReward = 5e17;
     uint256 public stakeAmount; //amount required to be a staker
     uint256 public totalStakeAmount; //total amount of tokens locked in contract (via stake)
     uint256 public reportingLock; // base amount of time before a reporter is able to submit a value again
@@ -73,8 +73,7 @@ contract TellorFlex {
         address _token,
         address _governance,
         uint256 _stakeAmount,
-        uint256 _reportingLock,
-        uint256 _timeBasedReward
+        uint256 _reportingLock
     ) {
         require(_token != address(0), "must set token address");
         require(_governance != address(0), "must set governance address");
@@ -82,7 +81,6 @@ contract TellorFlex {
         governance = _governance;
         stakeAmount = _stakeAmount;
         reportingLock = _reportingLock;
-        timeBasedReward = _timeBasedReward;
     }
 
     /**
@@ -280,7 +278,7 @@ contract TellorFlex {
         // Disperse Time Based Reward
         uint256 _timeDiff = block.timestamp - timeOfLastNewValue;
         uint256 _reward = (_timeDiff * timeBasedReward) / 300; //.5 TRB per 5 minutes
-        if (_reward > 0) {
+        if (_reward > 0 && token.balanceOf(address(this)) > _reward) {
             token.transfer(msg.sender, _reward);
         }
         // Update last oracle value and number of values submitted by a reporter

--- a/contracts/TellorFlex.sol
+++ b/contracts/TellorFlex.sol
@@ -14,6 +14,7 @@ import "./interfaces/IERC20.sol";
 contract TellorFlex {
     IERC20 public token;
     address public governance;
+    uint256 public timeBasedReward;
     uint256 public stakeAmount; //amount required to be a staker
     uint256 public totalStakeAmount; //total amount of tokens locked in contract (via stake)
     uint256 public reportingLock; // base amount of time before a reporter is able to submit a value again
@@ -72,7 +73,8 @@ contract TellorFlex {
         address _token,
         address _governance,
         uint256 _stakeAmount,
-        uint256 _reportingLock
+        uint256 _reportingLock,
+        uint256 _timeBasedReward
     ) {
         require(_token != address(0), "must set token address");
         require(_governance != address(0), "must set governance address");
@@ -80,6 +82,7 @@ contract TellorFlex {
         governance = _governance;
         stakeAmount = _stakeAmount;
         reportingLock = _reportingLock;
+        timeBasedReward = _timeBasedReward;
     }
 
     /**

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -13,4 +13,6 @@ interface IERC20 {
         address recipient,
         uint256 amount
     ) external returns (bool);
+
+    function mintToOracle() external;
 }

--- a/contracts/testing/StakingToken.sol
+++ b/contracts/testing/StakingToken.sol
@@ -4,9 +4,11 @@ pragma solidity 0.8.3;
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract StakingToken is ERC20 {
+
   constructor() ERC20("Test Tellor Tribute", "TTRB") {}
 
   function mint(address _to, uint256 _amount) public {
     _mint(_to, _amount);
   }
+
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -44,7 +44,7 @@ require("dotenv").config();
         count: 40,
       },
       forking: {
-        url: "https://eth-mainnet.alchemyapi.io/v2/7dW8KCqWwKa1vdaitq-SxmKfxWZ4yPG6"
+        url: process.env.FORKING_NODE_URL
       },
       allowUnlimitedContractSize: true
     },


### PR DESCRIPTION
Let me know what you guys think, I added a mapping that tracks the TRB locked for staking, staking rewards, and time based rewards. I added it because in testing I found that TRB could deposited for one purpose (i.e. staking rewards), then used for another (TBR). This could cause reporter slashing and staking reward dispersal to revert when the contract balance is too low.

I added a check in `submitValue` that the TBR is only dispersed if TBR tokens are held in the contract, according to the mapping.

Thoughts welcome